### PR TITLE
Add paths for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "vendor/github.com/kisielk/errcheck"]
+	path = vendor/github.com/kisielk/errcheck
+	url = https://github.com/kisielk/errcheck.git
+[submodule "vendor/github.com/kisielk/gotool"]
+	path = vendor/github.com/kisielk/gotool
+	url = https://github.com/kisielk/gotool.git


### PR DESCRIPTION
```
12:28:15 c1-linuxdev ~ $ go get -v github.com/mephux/vendorlint
github.com/mephux/vendorlint (download)
# cd /home/tlambiris/Documents/Go/src/github.com/mephux/vendorlint; git submodule update --init --recursive
fatal: No url found for submodule path 'vendor/github.com/kisielk/errcheck' in .gitmodules
package github.com/mephux/vendorlint: exit status 128
```

Fixes the following error when vendored code doesn't exist locally:
```
12:28:19 c1-linuxdev ~ $ go get -v github.com/tonylambiris/vendorlint
github.com/tonylambiris/vendorlint (download)
github.com/kisielk/gotool (download)
github.com/mephux/vendorlint/vendor/github.com/mattn/go-colorable
github.com/mephux/vendorlint/vendor/github.com/mattn/go-isatty
github.com/kisielk/gotool
github.com/mephux/vendorlint/vendor/github.com/fatih/color
github.com/mephux/vendorlint/vendorlint
github.com/tonylambiris/vendorlint
