### PR TITLE
Fix file matching for go source files

### DIFF
--- a/vendorlint/lint.go
+++ b/vendorlint/lint.go
@@ -121,8 +121,8 @@ func (l *Linter) run() error {
 		filepath.Walk(imp, func(path string,
 			f os.FileInfo, err error) error {
 
-			if strings.Contains(path, ".go") {
-				if strings.Contains(path, "_test.go") {
+			if strings.HasSuffix(path, ".go") {
+				if strings.HasSuffix(path, "_test.go") {
 					if l.Config.Tests {
 						files = append(files, path)
 					}


### PR DESCRIPTION
Fixes the following issue:
```
14:36:35 c1-linuxdev (master) ...src/github.com/kolide/kolide $ vendorlint -m
vendor/github.com/go-xorm/xorm/.gopmfile:1:1: expected 'package', found '['
Dependency Total: 16 Missing: 0
```
```
14:39:33 c1-linuxdev (master) ...src/github.com/kolide/kolide $ vendorlint -m

Dependency Total: 16 Missing: 0
```