### PR TITLE
Option to only output vendor paths

### DIFF
--- a/vendorlint.go
+++ b/vendorlint.go
@@ -13,7 +13,7 @@ const (
 	Name = "vendorlint"
 
 	// Version of the application
-	Version = "0.1.1"
+	Version = "0.1.2"
 )
 
 func main() {
@@ -28,6 +28,7 @@ func main() {
 	tests := flag.Bool("t", false, "include test dependencies")
 	missing := flag.Bool("m", false, "report missing dependencies")
 	all := flag.Bool("a", false, "report all dependencies")
+	paths := flag.Bool("p", false, "only output vendor paths")
 
 	version := flag.Bool("v", false, fmt.Sprintf("%s version number", Name))
 
@@ -42,6 +43,7 @@ func main() {
 	config.Missing = *missing
 	config.All = *all
 	config.Tests = *tests
+	config.Paths = *paths
 	config.Packages = flag.Args()
 
 	if !config.Missing && !config.All {
@@ -60,7 +62,7 @@ func main() {
 	}
 
 	if linter, err := vendorlint.NewLinter(config); err == nil {
-		linter.Report(config)
+		linter.Report()
 	} else {
 		// error!
 	}

--- a/vendorlint/config.go
+++ b/vendorlint/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	Missing          bool
 	Packages         []string
 	Tests            bool
+	Paths            bool
 	WorkingDirectory string
 }
 
@@ -18,5 +19,6 @@ func NewConfig() *Config {
 		Missing:  false,
 		Packages: []string{},
 		Tests:    false,
+		Paths:    false,
 	}
 }

--- a/vendorlint/lint.go
+++ b/vendorlint/lint.go
@@ -60,20 +60,24 @@ func NewLinter(config *Config) (*Linter, error) {
 }
 
 // Report writes all failed vendor deps
-func (l *Linter) Report(config *Config) {
+func (l *Linter) Report() {
 
 	var depcount int
 	var missingcount int
 
 	for _, i := range l.Imports {
-		if config.All {
+		if l.Config.All {
 			fmt.Fprintf(os.Stdout, "%s\n", i.Name)
 		}
 
 		if !hasVendorMatch(i.Name) {
-			if config.Missing {
-				color.Red("[X] Dependency not vendored: %s\n", i.Name)
-				fmt.Fprintf(os.Stderr, "  * %s\n", i.Position.String())
+			if l.Config.Missing {
+				if !l.Config.Paths {
+					color.Red("[X] Dependency not vendored: %s\n", i.Name)
+					fmt.Fprintf(os.Stderr, "  * %s\n", i.Position.String())
+				} else {
+					fmt.Fprintf(os.Stdout, "%s\n", i.Name)
+				}
 			}
 
 			missingcount++
@@ -82,7 +86,9 @@ func (l *Linter) Report(config *Config) {
 		depcount++
 	}
 
-	fmt.Fprintf(os.Stdout, "\nDependency Total: %d Missing: %d\n", depcount, missingcount)
+	if !l.Config.Paths {
+		fmt.Fprintf(os.Stdout, "\nDependency Total: %d Missing: %d\n", depcount, missingcount)
+	}
 
 	if missingcount > 0 {
 		os.Exit(1)


### PR DESCRIPTION
Creates a `-p` flag to only output vendor paths for easier parsing.

Also removes passing duplicate config struct.